### PR TITLE
[Feature, KEY-23] add owner awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The Test UI for the SelfKey Crowdsale
 
+Deployed to http://selfkey-crowdsale-tester.netlify.com
+
 * `develop` [![Build Status](https://www.travis-ci.org/SelfKeyFoundation/crowdsale-tester.svg?branch=develop)](https://www.travis-ci.org/SelfKeyFoundation/crowdsale-tester)
 * `master` [![Build Status](https://www.travis-ci.org/SelfKeyFoundation/crowdsale-tester.svg?branch=master)](https://www.travis-ci.org/SelfKeyFoundation/crowdsale-tester)
 

--- a/src/components/Contract/loadABI.js
+++ b/src/components/Contract/loadABI.js
@@ -10,7 +10,7 @@ const loadABI = contract => async dispatch => {
     const abi = await result.json()
     dispatch(makeAction(ABI_LOAD_SUCCESS, { contract, abi }))
   } catch (err) {
-    console.error('Caught error', err)
+    console.error(err)
     dispatch(makeAction(ABI_LOAD_FAIL, { contract, error: err.message }))
   }
 }

--- a/src/components/Crowdsale/getCrowdsaleData.js
+++ b/src/components/Crowdsale/getCrowdsaleData.js
@@ -28,7 +28,7 @@ const getCrowdsaleData = abi => async dispatch => {
       })
     )
   } catch (err) {
-    console.error('caught error', err)
+    console.error(err)
     dispatch(makeAction(CROWDSALE_DATA_GET_FAIL, err.message))
   }
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,9 +2,11 @@ import React from 'react'
 
 // import { Grid, Row, Col, Image } from 'react-bootstrap'
 
+const year = new Date().getFullYear()
+
 const Footer = () => (
   <footer>
-    <p>Footer goes here</p>
+    <p>©{year} SelfKeyFoundation</p>
   </footer>
 )
 

--- a/src/components/KYC/verifyKYC.js
+++ b/src/components/KYC/verifyKYC.js
@@ -2,19 +2,24 @@ import contractAccess from '../../utils/contractAccess'
 import makeAction from '../../utils/actionMaker'
 import { KYC_VERIFY, KYC_VERIFY_SUCCESS, KYC_VERIFY_FAIL } from './actions'
 
-import { CROWDSALE_ADDRESS } from '../../constants'
+import { CROWDSALE_ADDRESS, ERRORS } from '../../constants'
 
-const verifyKYC = (address, abi) => async dispatch => {
-  if (!address || address === '') {
-    dispatch(makeAction(KYC_VERIFY_FAIL, 'Invalid Address'))
+const { invalidAddress, notCrowdsaleOwner } = ERRORS
+
+const verifyKYC = (addressToVerify, abi) => async (dispatch, getState) => {
+  const { owner: { address, isOwner } } = getState()
+  if (!addressToVerify || addressToVerify === '') {
+    dispatch(makeAction(KYC_VERIFY_FAIL, invalidAddress))
+  } else if (!isOwner) {
+    dispatch(makeAction(KYC_VERIFY_FAIL, notCrowdsaleOwner))
   } else {
-    dispatch(makeAction(KYC_VERIFY, address))
+    dispatch(makeAction(KYC_VERIFY, addressToVerify))
     try {
       const crowdsale = contractAccess(CROWDSALE_ADDRESS, abi)
-      await crowdsale.verifyKYC(address)
+      await crowdsale.verifyKYC(addressToVerify, { from: address })
       dispatch(makeAction(KYC_VERIFY_SUCCESS))
     } catch (err) {
-      console.error('caught error', err)
+      console.error(err)
       dispatch(makeAction(KYC_VERIFY_FAIL, err.message))
     }
   }

--- a/src/components/Owner/Owner.jsx
+++ b/src/components/Owner/Owner.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { Label } from 'react-bootstrap'
+
+const Owner = ({ isOwner }) => {
+  const bsStyle = isOwner ? 'success' : 'danger'
+  const label = isOwner ? 'Crowdsale Owner' : 'Not Crowdsale Owner'
+  return <Label bsStyle={bsStyle}>{label}</Label>
+}
+
+Owner.propTypes = { isOwner: PropTypes.bool.isRequired }
+
+export default Owner

--- a/src/components/Owner/OwnerData.jsx
+++ b/src/components/Owner/OwnerData.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { connect } from 'react-redux'
+
+import { abiPropType } from '../../utils/shapes'
+import getOwner from './getOwner'
+
+class OwnerData extends React.Component {
+  componentWillMount() {
+    const { abi, doGetOwner } = this.props
+    doGetOwner(abi)
+  }
+
+  render() {
+    const { loading, error, isOwner } = this.props
+    if (loading) return <p>loading crowdsale owner</p>
+    if (error) return <p>error: {error}</p>
+    return (
+      <section id="crowdsale-data">{this.props.children({ isOwner })}</section>
+    )
+  }
+}
+
+OwnerData.propTypes = {
+  children: PropTypes.func.isRequired,
+  doGetOwner: PropTypes.func.isRequired,
+  abi: abiPropType.isRequired,
+  isOwner: PropTypes.bool,
+  loading: PropTypes.bool,
+  error: PropTypes.string
+}
+
+OwnerData.defaultPropTypes = {
+  loading: false,
+  error: null,
+  isOwner: false
+}
+
+const mapStateToProps = ({ owner: { loading, error, isOwner } }) => ({
+  loading,
+  error,
+  isOwner
+})
+
+const mapDispatchToProps = dispatch => ({
+  doGetOwner: abi => dispatch(getOwner(abi))
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(OwnerData)

--- a/src/components/Owner/actions.js
+++ b/src/components/Owner/actions.js
@@ -1,0 +1,6 @@
+export const OWNER_LOAD = 'OWNER_LOAD'
+export const OWNER_LOAD_SUCCESS = 'OWNER_LOAD_SUCCESS'
+export const OWNER_LOAD_FAIL = 'OWNER_LOAD_FAIL'
+// and wrap the react-web3 actions
+export const ACCOUNT_RECEIVED = 'web3/RECEIVE_ACCOUNT'
+export const ACCOUNT_CHANGED = 'web3/CHANGE_ACCOUNT'

--- a/src/components/Owner/getOwner.js
+++ b/src/components/Owner/getOwner.js
@@ -1,0 +1,20 @@
+import makeAction from '../../utils/actionMaker'
+import contractAccess from '../../utils/contractAccess'
+
+import { OWNER_LOAD, OWNER_LOAD_SUCCESS, OWNER_LOAD_FAIL } from './actions'
+
+import { CROWDSALE_ADDRESS } from '../../constants'
+
+const getOwner = abi => async dispatch => {
+  dispatch(makeAction(OWNER_LOAD))
+  try {
+    const crowdsale = contractAccess(CROWDSALE_ADDRESS, abi)
+    const result = await crowdsale.owner()
+    dispatch(makeAction(OWNER_LOAD_SUCCESS, result[0]))
+  } catch (err) {
+    console.error(err)
+    dispatch(makeAction(OWNER_LOAD_FAIL, err.message))
+  }
+}
+
+export default getOwner

--- a/src/components/Owner/reducer.js
+++ b/src/components/Owner/reducer.js
@@ -1,0 +1,56 @@
+import {
+  OWNER_LOAD,
+  OWNER_LOAD_SUCCESS,
+  OWNER_LOAD_FAIL,
+  ACCOUNT_RECEIVED, // carries address in action.address not payload.
+  ACCOUNT_CHANGED // carries address in action.address not payload.
+} from './actions'
+
+const INITIAL_STATE = {
+  isOwner: false,
+  loading: false,
+  error: null,
+  owner: null,
+  address: null
+}
+
+const reducer = (state = INITIAL_STATE, action) => {
+  const { type, payload, address } = action
+  switch (type) {
+    case ACCOUNT_RECEIVED: {
+      const isOwner = address && state.owner && address === state.owner
+      return { ...state, address, isOwner }
+    }
+    case ACCOUNT_CHANGED: {
+      const isOwner = address && state.owner && address === state.owner
+      return { ...state, address, isOwner }
+    }
+    case OWNER_LOAD: {
+      return { ...state, loading: true }
+    }
+    case OWNER_LOAD_SUCCESS: {
+      const isOwner = payload && state.address && payload === state.address
+      return {
+        ...state,
+        loading: false,
+        owner: payload,
+        error: null,
+        isOwner
+      }
+    }
+    case OWNER_LOAD_FAIL: {
+      return {
+        ...state,
+        loading: false,
+        isOwner: false,
+        owner: null,
+        error: payload
+      }
+    }
+    default: {
+      return state
+    }
+  }
+}
+
+export default reducer

--- a/src/components/StatusCheck/checkStatus.js
+++ b/src/components/StatusCheck/checkStatus.js
@@ -6,11 +6,13 @@ import {
   STATUS_CHECK_FAIL
 } from './actions'
 
-import { CROWDSALE_ADDRESS } from '../../constants'
+import { CROWDSALE_ADDRESS, ERRORS } from '../../constants'
+
+const { invalidAddress } = ERRORS
 
 const checkStatus = (address, abi) => async dispatch => {
   if (!address || address === '') {
-    dispatch(makeAction(STATUS_CHECK_FAIL, 'Invalid Address'))
+    dispatch(makeAction(STATUS_CHECK_FAIL, invalidAddress))
   } else {
     dispatch(makeAction(STATUS_CHECK, address))
     try {

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,3 +8,8 @@ export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 export const CROWDSALE_ADDRESS = REACT_APP_CROWDSALE_ADDRESS
 export const ETH_PROVIDER_URL = REACT_APP_ETH_PROVIDER_URL
 export const TOKEN_ADDRESS = REACT_APP_TOKEN_ADDRESS
+
+export const ERRORS = {
+  invalidAddress: 'Invalid Address',
+  notCrowdsaleOwner: 'You are not the owner of the Crowdsale Contract'
+}

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -6,6 +6,7 @@ import statusCheck from '../components/StatusCheck/reducer'
 import kyc from '../components/KYC/reducer'
 import contract from '../components/Contract/reducer'
 import crowdsale from '../components/Crowdsale/reducer'
+import owner from '../components/Owner/reducer'
 
 export default combineReducers({
   routing,
@@ -13,5 +14,6 @@ export default combineReducers({
   statusCheck,
   kyc,
   contract,
-  crowdsale
+  crowdsale,
+  owner
 })

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -48,11 +48,9 @@ const Home = () => (
                                   weiRaised={weiRaised}
                                   tokensPurchased={tokensPurchased}
                                 />
+                                <StatusCheck abi={SelfkeyCrowdsale} />
                                 {isOwner && (
-                                  <section id="owner-actions">
-                                    <StatusCheck abi={SelfkeyCrowdsale} />
-                                    <KYCVerification abi={SelfkeyCrowdsale} />
-                                  </section>
+                                  <KYCVerification abi={SelfkeyCrowdsale} />
                                 )}
                               </section>
                             )}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -5,6 +5,8 @@ import { Row, Col } from 'react-bootstrap'
 import Page from '../components/Page.jsx'
 import Title from '../components/Title.jsx'
 import ABI from '../components/Contract/ABI.jsx'
+import OwnerData from '../components/Owner/OwnerData.jsx'
+import Owner from '../components/Owner/Owner.jsx'
 import CrowdsaleData from '../components/Crowdsale/CrowdsaleData.jsx'
 import CrowdsaleDates from '../components/Crowdsale/CrowdsaleDates.jsx'
 import CrowdsaleStats from '../components/Crowdsale/CrowdsaleStats.jsx'
@@ -27,27 +29,36 @@ const Home = () => (
                     console.debug('SelfkeyCrowdsale', SelfkeyCrowdsale)
                     if (!SelfkeyCrowdsale) return null
                     return (
-                      <CrowdsaleData abi={SelfkeyCrowdsale}>
-                        {({
-                          startTime,
-                          endTime,
-                          weiRaised,
-                          tokensPurchased
-                        }) => (
-                          <section>
-                            <CrowdsaleDates
-                              startDate={startTime}
-                              endDate={endTime}
-                            />
-                            <CrowdsaleStats
-                              weiRaised={weiRaised}
-                              tokensPurchased={tokensPurchased}
-                            />
-                            <StatusCheck abi={SelfkeyCrowdsale} />
-                            <KYCVerification abi={SelfkeyCrowdsale} />
-                          </section>
+                      <OwnerData abi={SelfkeyCrowdsale}>
+                        {({ isOwner }) => (
+                          <CrowdsaleData abi={SelfkeyCrowdsale}>
+                            {({
+                              startTime,
+                              endTime,
+                              weiRaised,
+                              tokensPurchased
+                            }) => (
+                              <section>
+                                <Owner isOwner={isOwner} />
+                                <CrowdsaleDates
+                                  startDate={startTime}
+                                  endDate={endTime}
+                                />
+                                <CrowdsaleStats
+                                  weiRaised={weiRaised}
+                                  tokensPurchased={tokensPurchased}
+                                />
+                                {isOwner && (
+                                  <section id="owner-actions">
+                                    <StatusCheck abi={SelfkeyCrowdsale} />
+                                    <KYCVerification abi={SelfkeyCrowdsale} />
+                                  </section>
+                                )}
+                              </section>
+                            )}
+                          </CrowdsaleData>
                         )}
-                      </CrowdsaleData>
+                      </OwnerData>
                     )
                   }}
                 </ABI>


### PR DESCRIPTION
## Improvements

* Check if the address unlocked with MetaMask is the owner of the Crowdsale contract. `isOwner` then allow the user to verify or reject KYC for an address, and display a green badge, else display a red badge advising the unlocked address is not the contract owner, and don't show the KYC validation interface.
* Added a `©2017 SelfKey Foundation` notice to the footer.
* Add a `{ from: address }` clause to the calls to `verifyKYC` and `rejectKYC` as they are flagged as `onlyOwner`.
* Consolidated error messages into the `./constants.js` file.
